### PR TITLE
flake: bump pinned Nix to 2.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667318659,
-        "narHash": "sha256-mRXqCdlnxPgm3Wk7mNAOanl7B3Q3U5scYTEiyYmNEOE=",
+        "lastModified": 1684922889,
+        "narHash": "sha256-l0WZAmln8959O7RdYUJ3gnAIM9OPKFLKHKGX4q+Blrk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3a8f7ed267e0a7ed100eb7d716c9137ff120fe3",
+        "rev": "04aaf8511678a0d0f347fdf1e8072fe01e4a509e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,20 @@
 {
   description = "Nix binary cache garbage collector";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-22.05;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05;
 
   outputs = { self, nixpkgs }: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
     overlays.default = final: prev: {
-      cache-gc = prev.callPackage ./package.nix { nix = final.nixVersions.nix_2_9; src = self; };
+      cache-gc = prev.callPackage ./package.nix { nix = final.nixVersions.nix_2_13; src = self; };
     };
 
     defaultPackage = forAllSystems (system: self.packages.${system}.cache-gc);
     packages = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in rec {
-      cache-gc = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.nix_2_9; src = self; };
+      cache-gc = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.nix_2_13; src = self; };
       default = cache-gc;
     });
 


### PR DESCRIPTION
2.9 doesn't exist anymore on master & release-23.05, so cache-gc doesn't evaluate there anymore.

cc @lheckemann 