### PR TITLE
Update nixpkgs & use Nix 2.19

### DIFF
--- a/add-registration-times.jq
+++ b/add-registration-times.jq
@@ -2,7 +2,8 @@
 def path_to_hash: match("/?([0-9a-z]{32})-?") | .captures[0].string;
 
 ($dates | map(. / " " | { name: .[1][:32], value: (.[0] | tonumber) }) | from_entries) as $registrationTimes
-| map(. + {
-  registrationTime: ($registrationTimes[(.path | path_to_hash)])
+| to_entries | map(.value + {
+  registrationTime: ($registrationTimes[(.key | path_to_hash)]),
+  path: .key
 })
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684922889,
-        "narHash": "sha256-l0WZAmln8959O7RdYUJ3gnAIM9OPKFLKHKGX4q+Blrk=",
+        "lastModified": 1710565619,
+        "narHash": "sha256-xu/EnZCNdIj7m/QjCNIG5vrCA4TYg5uwFReb9XDxET0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04aaf8511678a0d0f347fdf1e8072fe01e4a509e",
+        "rev": "8ac30a39abc5ea67037dfbf090d6e89f187c6e50",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,20 @@
 {
   description = "Nix binary cache garbage collector";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
 
   outputs = { self, nixpkgs }: let
     forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
   in {
     overlays.default = final: prev: {
-      cache-gc = prev.callPackage ./package.nix { nix = final.nixVersions.nix_2_13; src = self; };
+      cache-gc = prev.callPackage ./package.nix { nix = final.nixVersions.nix_2_19; src = self; };
     };
 
     defaultPackage = forAllSystems (system: self.packages.${system}.cache-gc);
     packages = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages.${system};
     in rec {
-      cache-gc = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.nix_2_13; src = self; };
+      cache-gc = pkgs.callPackage ./package.nix { nix = pkgs.nixVersions.nix_2_19; src = self; };
       default = cache-gc;
     });
 


### PR DESCRIPTION
Since cc46ea163024254d0b74646e1b38b19896d40040 `nix path-info --json --all` returns an object where `path` is the key. Updated `add-registration-times.jq` accordingly.

cc @lheckemann 