### PR TITLE
Fix regression with Nix 2.19

### DIFF
--- a/add-registration-times.jq
+++ b/add-registration-times.jq
@@ -1,9 +1,0 @@
-# nix path-info --all --json --store file:/$cache | jq --slurpfile dates <(echo $cache/*.narinfo | xargs stat -c '%Y %n' -- | jq -R)
-def path_to_hash: match("/?([0-9a-z]{32})-?") | .captures[0].string;
-
-($dates | map(. / " " | { name: .[1][:32], value: (.[0] | tonumber) }) | from_entries) as $registrationTimes
-| to_entries | map(.value + {
-  registrationTime: ($registrationTimes[(.key | path_to_hash)]),
-  path: .key
-})
-

--- a/add-registration-times.py
+++ b/add-registration-times.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+from glob import glob
+import json
+import os
+import re
+import sys
+
+
+NARINFO_PREFIX = 'StorePath: '
+
+
+def get_store_path(hash):
+    with open(f"{hash}.narinfo") as f:
+        first_line = f.readline().strip()
+        assert first_line.startswith(NARINFO_PREFIX)
+        return first_line[len(NARINFO_PREFIX):]
+
+
+def enrich(key, path_info):
+    hash = re.search('/?(?P<hash>[0-9a-z]{32})-?', key).group('hash')
+    path_info['registrationTime'] = round(os.stat(f"{hash}.narinfo").st_mtime)
+    path_info['path'] = get_store_path(hash)
+
+    return path_info
+
+
+print(json.dumps(list(
+    enrich(k, v) for k, v in json.load(sys.stdin).items()
+)))

--- a/package.nix
+++ b/package.nix
@@ -1,17 +1,18 @@
-{ nix, rustPlatform, lib, coreutils, jq, findutils, bash, src ? lib.cleanSource ./. }:
+{ nix, rustPlatform, lib, coreutils, findutils, bash, src ? lib.cleanSource ./., python3 }:
 rustPlatform.buildRustPackage {
   inherit src;
   pname = "cache-gc";
   version = "unstable" + lib.optionalString ((src.sourceInfo or {}) ? lastModifiedDate) "-${lib.substring 0 8 src.sourceInfo.lastModifiedDate}";
   cargoLock.lockFile = ./Cargo.lock;
-  buildInputs = [ bash ];
+  buildInputs = [ bash python3 ];
   postInstall = ''
     mkdir -p $out/libexec/cache-gc
     mv $out/bin/gc $out/libexec/cache-gc/
-    cp $src/add-registration-times.jq $out/libexec/cache-gc
+    cp $src/add-registration-times.py $out/libexec/cache-gc
+    patchShebangs $out/libexec/cache-gc
     install -m0755 $src/run.sh $out/bin/cache-gc
     sed -i $out/bin/cache-gc \
-      -e "2iexport PATH=$out/libexec/cache-gc:${lib.makeBinPath [ coreutils jq nix findutils ]}" \
+      -e "2iexport PATH=$out/libexec/cache-gc:${lib.makeBinPath [ coreutils nix findutils ]}" \
       -e "2ilibexec_dir=$out/libexec/cache-gc"
     patchShebangs $out/bin/cache-gc
   '';

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ confirm() {
 }
 
 : "${libexec_dir:="$(dirname "$(readlink -f "$0")")/../libexec/cache-gc"}"
-[[ -r "$libexec_dir/add-registration-times.jq" ]] || error "Couldn't find registration time adder, are we installed correctly?"
+[[ -r "$libexec_dir/add-registration-times.py" ]] || error "Couldn't find registration time adder, are we installed correctly?"
 
 usage() {
     error "Usage: $0 [--days 90] [--delete] <cache-dir>"
@@ -46,7 +46,7 @@ done
 
 paths_to_delete=$(
     nix path-info --all --json --store file://"$cache_dir" --option extra-experimental-features "nix-command" |
-        jq -f "$libexec_dir/add-registration-times.jq" --slurpfile dates <(cd "$cache_dir"; echo *.narinfo | xargs stat -c '%Y %n' -- | jq -R) |
+        (cd "$cache_dir"; "$libexec_dir"/add-registration-times.py) |
         gc "${gc_args[@]}"
 )
 


### PR DESCRIPTION
Apparently newer Nix versions are again displaying store paths in the format

  `/nix/store/<hash>-x`

when running `nix path-info --all --json`.

This caused `cache-gc` to delete a lot of paths to delete that shouldn't be deleted leaving my Hydra with a corrupted binary cache.

While this certainly needs an upstream bugreport, I decided to hack around that by reading the `.narinfo` files directly to get the correct store path because I wanted a quick fix.

I originally wanted to do that with a second slurpfile, but the IO involved with reading >10k `.narinfo` files caused a significant slowdown on my end, so I decided to rewrite the `jq`-part with Python so that I never have to shell out for the store-path detection or performing `stat(1)`.